### PR TITLE
(feat): customize ui

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -113,7 +113,11 @@ export default function Index() {
                   <p>Work</p>
                   <ul className="ml-8 list-disc">
                     {week.work.map((entry) => (
-                      <EntryListItem key={entry.id} entry={entry} />
+                      <EntryListItem
+                        key={entry.id}
+                        entry={entry}
+                        canEdit={session.isAdmin}
+                      />
                     ))}
                   </ul>
                 </div>
@@ -123,7 +127,11 @@ export default function Index() {
                   <p>Learnings</p>
                   <ul className="ml-8 list-disc">
                     {week.learnings.map((entry) => (
-                      <EntryListItem key={entry.id} entry={entry} />
+                      <EntryListItem
+                        key={entry.id}
+                        entry={entry}
+                        canEdit={session.isAdmin}
+                      />
                     ))}
                   </ul>
                 </div>
@@ -133,7 +141,11 @@ export default function Index() {
                   <p>Interesting things</p>
                   <ul className="ml-8 list-disc">
                     {week.interestingThings.map((entry) => (
-                      <EntryListItem key={entry.id} entry={entry} />
+                      <EntryListItem
+                        key={entry.id}
+                        entry={entry}
+                        canEdit={session.isAdmin}
+                      />
                     ))}
                   </ul>
                 </div>
@@ -148,19 +160,23 @@ export default function Index() {
 
 function EntryListItem({
   entry,
+  canEdit,
 }: {
   entry: Awaited<ReturnType<typeof loader>>['entries'][number];
+  canEdit: boolean;
 }) {
   return (
     <li className="group">
       {entry.text}
 
-      <Link
-        to={`entries/${entry.id}/edit`}
-        className="ml-2 text-blue-500 opacity-0 group-hover:opacity-100"
-      >
-        Edit
-      </Link>
+      {canEdit && (
+        <Link
+          to={`entries/${entry.id}/edit`}
+          className="ml-2 text-blue-500 opacity-0 group-hover:opacity-100"
+        >
+          Edit
+        </Link>
+      )}
     </li>
   );
 }

--- a/app/routes/entries.$entryId.edit.tsx
+++ b/app/routes/entries.$entryId.edit.tsx
@@ -3,8 +3,9 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
 import { Form, redirect, useLoaderData } from '@remix-run/react';
 import type { FormEvent } from 'react';
 import { EntryForm } from '~/components/entry-form';
+import { getSession } from '~/session';
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ request, params }: LoaderFunctionArgs) {
   if (typeof params.entryId !== 'string') {
     throw new Response('Not found', { status: 404 });
   }
@@ -19,6 +20,11 @@ export async function loader({ params }: LoaderFunctionArgs) {
 
   if (!entry) {
     throw new Response('Not found', { status: 404 });
+  }
+
+  const session = await getSession(request.headers.get('Cookie'));
+  if (session.data.isAdmin !== true) {
+    throw new Response('Not authenticated', { status: 401 });
   }
 
   return {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Enhanced the `EntryListItem` component in `_index.tsx` to accept a `canEdit` prop, allowing edit capabilities based on admin status.
- Implemented conditional rendering of the edit link in the `EntryListItem` component, visible only to admins.
- Updated the loader function in `entries.$entryId.edit.tsx` to fetch session details and added an admin check before allowing entry edits.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_index.tsx</strong><dd><code>Enhance Entry List Items with Admin Edit Capabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
app/routes/_index.tsx

<li>Added <code>canEdit</code> prop to <code>EntryListItem</code> component based on <br><code>session.isAdmin</code>.<br> <li> Conditionally render edit link for entries if the user is an admin.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Ronny25/Build-UI-Work-Journal/pull/18/files#diff-8bd8555c577836673951723e36b75ebd6b5ffbb87f0220c01a5b1149c8c7f525">+25/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>entries.$entryId.edit.tsx</strong><dd><code>Add Admin Authentication for Entry Edit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
app/routes/entries.$entryId.edit.tsx

<li>Modified loader function to include session check.<br> <li> Added authentication check to restrict edit access to admins only.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Ronny25/Build-UI-Work-Journal/pull/18/files#diff-0a8b8bdf910561a890f3ed7af168e791888f08443bedbbf54618fbca46a13d96">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

