### PR TITLE
(feat): customize errors UI

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,8 +6,10 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  isRouteErrorResponse,
   redirect,
   useLoaderData,
+  useRouteError,
 } from '@remix-run/react';
 import type {
   ActionFunctionArgs,
@@ -79,6 +81,28 @@ export default function App() {
         )}
       </div>
       <Outlet />
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  return (
+    <div className="h-screen">
+      <div className="flex h-full flex-col items-center justify-center">
+        <p className="text-3xl">Whoops!</p>
+
+        {isRouteErrorResponse(error) ? (
+          <p>
+            {error.status} - {error.statusText}
+          </p>
+        ) : error instanceof Error ? (
+          <p>{error.message}</p>
+        ) : (
+          <p>Unknown error</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -12,7 +12,10 @@ import { getSession } from '~/session';
 export async function action({ request }: ActionFunctionArgs) {
   const session = await getSession(request.headers.get('Cookie'));
   if (session.data.isAdmin !== true) {
-    throw new Response('Not authenticated', { status: 401 });
+    throw new Response('Not authenticated', {
+      status: 401,
+      statusText: 'Not authenticated',
+    });
   }
 
   const db = new PrismaClient();
@@ -26,7 +29,10 @@ export async function action({ request }: ActionFunctionArgs) {
     typeof type !== 'string' ||
     typeof text !== 'string'
   ) {
-    throw new Response('Invalid data', { status: 400 });
+    throw new Response('Invalid data', {
+      status: 400,
+      statusText: 'Invalid data',
+    });
   }
 
   try {

--- a/app/routes/entries.$entryId.edit.tsx
+++ b/app/routes/entries.$entryId.edit.tsx
@@ -7,7 +7,7 @@ import { getSession } from '~/session';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   if (typeof params.entryId !== 'string') {
-    throw new Response('Not found', { status: 404 });
+    throw new Response('Not found', { status: 404, statusText: 'Not found' });
   }
 
   const db = new PrismaClient();
@@ -19,12 +19,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   await db.$disconnect();
 
   if (!entry) {
-    throw new Response('Not found', { status: 404 });
+    throw new Response('Not found', { status: 404, statusText: 'Not found' });
   }
 
   const session = await getSession(request.headers.get('Cookie'));
   if (session.data.isAdmin !== true) {
-    throw new Response('Not authenticated', { status: 401 });
+    throw new Response('Not authenticated', {
+      status: 401,
+      statusText: 'Not authenticated',
+    });
   }
 
   return {
@@ -36,11 +39,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 export async function action({ request, params }: ActionFunctionArgs) {
   const session = await getSession(request.headers.get('Cookie'));
   if (session.data.isAdmin !== true) {
-    throw new Response('Not authenticated', { status: 401 });
+    throw new Response('Not authenticated', {
+      status: 401,
+      statusText: 'Not authenticated',
+    });
   }
 
   if (typeof params.entryId !== 'string') {
-    throw new Response('Not found', { status: 404 });
+    throw new Response('Not found', { status: 404, statusText: 'Not found' });
   }
 
   const db = new PrismaClient();


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Added an `ErrorBoundary` function in `app/root.tsx` to handle errors more effectively using `useRouteError`.
- Enhanced error handling across various routes by including `statusText` in error responses for clearer error messaging.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>root.tsx</strong><dd><code>Implement Enhanced Error Handling in Root Component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
app/root.tsx

<li>Added <code>isRouteErrorResponse</code> and <code>useRouteError</code> imports.<br> <li> Implemented a new <code>ErrorBoundary</code> function to handle and display errors <br>more effectively.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Ronny25/Build-UI-Work-Journal/pull/20/files#diff-4133eb55408b25b35b8e07c696a9dfc97b741c555d7407e8c86d0845e5eecc28">+24/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_index.tsx</strong><dd><code>Improve Error Messaging in Index Route Actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
app/routes/_index.tsx

<li>Modified error responses to include <code>statusText</code> for better error <br>description.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Ronny25/Build-UI-Work-Journal/pull/20/files#diff-8bd8555c577836673951723e36b75ebd6b5ffbb87f0220c01a5b1149c8c7f525">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug_fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entries.$entryId.edit.tsx</strong><dd><code>Standardize Error Responses in Entry Edit Route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
app/routes/entries.$entryId.edit.tsx

- Standardized error responses with `statusText` for clarity.



</details>
    

  </td>
  <td><a href="https://github.com/Ronny25/Build-UI-Work-Journal/pull/20/files#diff-0a8b8bdf910561a890f3ed7af168e791888f08443bedbbf54618fbca46a13d96">+11/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

